### PR TITLE
Rename project to xiTools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# xiNAS
+# xiTools
 
-This repository contains scripts and Ansible playbooks used to provision xiNAS nodes.
+xiTools is a set of utilities for operating system optimization and automated deployment of xiRAID Classic.
 
 ## Getting started
 


### PR DESCRIPTION
## Summary
- update project name in README to **xiTools**
- clarify that xiTools is a set of utilities for OS optimization and deployment of xiRAID Classic

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6880b3fb95d88328ba31df91899e2ebd