### PR TITLE
Add RedHat support to prepare_system script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ xiTools is a set of utilities for operating system optimization and automated de
 
 ## Getting started
 
-1. Run `prepare_system.sh` on the target host (use the `-e` option for expert mode). Use `-u` to update the repository without launching any menus. This installs required packages including `yq` version 4, `whiptail`, and Ansible, then clones the repository.
+1. Run `prepare_system.sh` on the target host (use the `-e` option for expert mode). Use `-u` to update the repository without launching any menus. The script now automatically detects Ubuntu or RedHat-based distributions and installs required packages (`yq` version 4, `whiptail`/`newt`, `ansible`, etc.) using the appropriate package manager before cloning the repository.
    The script immediately launches a simplified start menu in default mode to enter the license and choose a preset. Use `-e` to access the full interactive menu with additional options such as updating the repository or saving the current configuration as a new preset.
    Both menus now include a **Collect Data** option for gathering system information into a tar archive and uploading it via `transfer.sh`. The upload server is configured automatically and listens on port 8080. You can override it by setting the `TRANSFER_SERVER` environment variable if needed.
 
@@ -23,7 +23,7 @@ xiTools is a set of utilities for operating system optimization and automated de
    from there. If you choose to install DOCA OFED using the provided playbook,
    the script will automatically install Ansible packages when needed.
 
-The `prepare_system.sh` script installs dependencies required by the interactive helper scripts. The helper scripts rely on the [`mikefarah/yq`](https://github.com/mikefarah/yq) binary (v4+). If you encounter errors such as `jq: error: env/1 is not defined`, make sure this version of `yq` is installed by re-running `prepare_system.sh` or installing it manually.
+The `prepare_system.sh` script installs dependencies required by the interactive helper scripts. It works on both Ubuntu and RedHat-like systems by selecting `apt`, `dnf`, or `yum` as needed. The helper scripts rely on the [`mikefarah/yq`](https://github.com/mikefarah/yq) binary (v4+). If you encounter errors such as `jq: error: env/1 is not defined`, make sure this version of `yq` is installed by re-running `prepare_system.sh` or installing it manually.
 Earlier versions of the RAID configuration script failed with `'//' expects 2 args but there is 1` when no spare pool existed. The script now creates the pool automatically the first time you enter devices.
 You can inspect all `yq` binaries with `which -a yq`. If multiple paths are listed, reorder your `PATH` so `/usr/local/bin/yq` precedes others or remove the older version entirely.
 

--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -21,8 +21,17 @@ done
 
 # Install required packages unless only updating the repository
 if [ "$UPDATE_ONLY" -eq 0 ]; then
-    sudo apt-get update -y
-    sudo apt-get install -y ansible git whiptail dialog wget
+    if command -v apt-get >/dev/null 2>&1; then
+        sudo apt-get update -y
+        sudo apt-get install -y ansible git whiptail dialog wget
+    elif command -v dnf >/dev/null 2>&1; then
+        sudo dnf install -y ansible git newt dialog wget
+    elif command -v yum >/dev/null 2>&1; then
+        sudo yum install -y ansible git newt dialog wget
+    else
+        echo "Unsupported package manager. Install ansible, git, whiptail/newt, dialog, and wget manually." >&2
+        exit 1
+    fi
     # Install yq v4 for YAML processing used by configuration scripts
     sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64"
     sudo chmod +x /usr/local/bin/yq


### PR DESCRIPTION
## Summary
- detect apt, dnf or yum in `prepare_system.sh` to support Ubuntu and RedHat-based distros
- document automatic OS detection in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880b654ea508328963e7e61bcce0c6b