### PR TITLE
Add Performance Tuning menu

### DIFF
--- a/collection/roles/perf_tuning/README.md
+++ b/collection/roles/perf_tuning/README.md
@@ -25,3 +25,5 @@ the `linux-tools-common` package, which the role installs automatically.
   roles:
     - perf_tuning
 ```
+
+Reference: [xiNNOR blog on performance tuning](https://xinnor.io/blog/performance-tuning)

--- a/collection/roles/perf_tuning/handlers/main.yml
+++ b/collection/roles/perf_tuning/handlers/main.yml
@@ -2,8 +2,18 @@
 # handlers/main.yml
 # -------------------------------------------------------------
 ---
-- name: update grub
+- name: update grub on Debian/Ubuntu
   ansible.builtin.command: update-grub
+  when: ansible_os_family == 'Debian'
 
-- name: rebuild initramfs
+- name: update grub on RedHat
+  ansible.builtin.command: grub2-mkconfig -o /boot/grub2/grub.cfg
+  when: ansible_os_family == 'RedHat'
+
+- name: rebuild initramfs on Debian/Ubuntu
   ansible.builtin.command: update-initramfs -u -k all
+  when: ansible_os_family == 'Debian'
+
+- name: rebuild initramfs on RedHat
+  ansible.builtin.command: dracut -f
+  when: ansible_os_family == 'RedHat'

--- a/collection/roles/perf_tuning/tasks/main.yml
+++ b/collection/roles/perf_tuning/tasks/main.yml
@@ -2,13 +2,23 @@
 # tasks/main.yml
 # -------------------------------------------------------------
 ---
-- name: Install auxiliary packages needed by tuning tasks
+- name: Install auxiliary packages on Debian/Ubuntu
   ansible.builtin.apt:
     name:
       - cpufrequtils
       - linux-tools-common
       - tuned
     state: present
+  when: ansible_os_family == 'Debian'
+  tags: [packages]
+
+- name: Install auxiliary packages on RedHat
+  ansible.builtin.yum:
+    name:
+      - tuned
+      - kernel-tools
+    state: present
+  when: ansible_os_family == 'RedHat'
   tags: [packages]
 
 # ===== Kernel boot parameters =====

--- a/playbooks/perf_tuning.yml
+++ b/playbooks/perf_tuning.yml
@@ -1,0 +1,6 @@
+---
+- name: Apply performance tuning
+  hosts: storage_nodes
+  gather_facts: true
+  roles:
+    - role: perf_tuning


### PR DESCRIPTION
## Summary
- add dedicated perf_tuning playbook
- make perf_tuning role work on RedHat and Debian
- show role info and run perf tuning from menus
- mention xinnor blog link in role README

## Testing
- `shellcheck simple_menu.sh startup_menu.sh`
- `ansible-lint playbooks/perf_tuning.yml` *(fails: 27 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880cfd688fc83289e716e7ae1b600a4