### PR TITLE
Fix cpupower failure by installing kernel tools

### DIFF
--- a/collection/roles/perf_tuning/README.md
+++ b/collection/roles/perf_tuning/README.md
@@ -16,8 +16,10 @@ recommended in Xinnor blogs (2023-2025) and NVIDIA ConnectX-7 (400 Gbit) docs.
 ## Variables
 See `defaults/main.yml` for the full list; most tuning knobs can be disabled or
 altered via inventory variables. Notably, set `perf_disable_cpupower: true` to
-skip adjusting the CPU frequency governor. The `cpupower` tool is provided by
-the `linux-tools-common` package, which the role installs automatically.
+skip adjusting the CPU frequency governor. The `cpupower` tool is available
+through the `linux-tools` packages on Ubuntu (e.g. `linux-tools-$(uname -r)`).
+The role installs `linux-tools-common` along with the matching
+kernel-specific package automatically.
 
 ## Example
 ```yaml

--- a/collection/roles/perf_tuning/tasks/main.yml
+++ b/collection/roles/perf_tuning/tasks/main.yml
@@ -7,6 +7,7 @@
     name:
       - cpufrequtils
       - linux-tools-common
+      - "linux-tools-{{ ansible_kernel }}"
       - tuned
     state: present
   when: ansible_os_family == 'Debian'


### PR DESCRIPTION
## Summary
- install `linux-tools-{{ ansible_kernel }}` so `cpupower` works on Ubuntu
- document package requirements for cpupower in the role README

## Testing
- `ansible-playbook -i inventories/lab.ini playbooks/perf_tuning.yml --syntax-check`

------
https://chatgpt.com/codex/tasks/task_e_6880dc78f644832895788274e822f498