### PR TITLE
Remove license menu option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ xiTools is a set of utilities for operating system optimization and automated de
 ## Getting started
 
 1. Run `prepare_system.sh` on the target host (use the `-e` option for expert mode). Use `-u` to update the repository without launching any menus. The script now automatically detects Ubuntu or RedHat-based distributions and installs required packages (`yq` version 4, `whiptail`/`newt`, `ansible`, etc.) using the appropriate package manager before cloning the repository.
-   The script immediately launches a simplified start menu in default mode to enter the license and choose a preset. Use `-e` to access the full interactive menu with additional options such as updating the repository or saving the current configuration as a new preset.
+   The script immediately launches a simplified start menu in default mode to choose a preset. Use `-e` to access the full interactive menu with additional options such as updating the repository or saving the current configuration as a new preset.
    Both menus now include a **Collect Data** option for gathering system information into a tar archive and uploading it via `transfer.sh`. The upload server is configured automatically and listens on port 8080. You can override it by setting the `TRANSFER_SERVER` environment variable if needed.
 
    Example:

--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -10,7 +10,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 check_license() {
     local license_file="/tmp/license"
     if [ ! -f "$license_file" ]; then
-        whiptail --msgbox "License file $license_file not found. Please run 'Enter License' first." 10 60
+        whiptail --msgbox "License file $license_file not found. Please add the license file before continuing." 10 60
         return 1
     fi
     return 0

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -15,7 +15,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 check_license() {
     local license_file="/tmp/license"
     if [ ! -f "$license_file" ]; then
-        whiptail --msgbox "License file $license_file not found. Please run 'Enter License' first." 10 60
+        whiptail --msgbox "License file $license_file not found. Please add the license file before continuing." 10 60
         return 1
     fi
     return 0
@@ -128,21 +128,19 @@ configure_nfs_shares() {
 
     while true; do
         local choice
-    choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 20 70 16 \
-        1 "Enter License" \
-        2 "Configure Network" \
-        3 "Set Hostname" \
-        3 "Set Hostname" \
-        4 "Configure RAID" \
-        5 "Edit NFS Exports" \
-        6 "Presets" \
-        7 "Git Repository Configuration" \
-        8 "Install" \
-        9 "Exit" \
-        3>&1 1>&2 2>&3)
+        choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 20 70 15 \
+            1 "Configure Network" \
+            2 "Set Hostname" \
+            3 "Configure RAID" \
+            4 "Edit NFS Exports" \
+            5 "Presets" \
+            6 "Git Repository Configuration" \
+            7 "Install" \
+            8 "Exit" \
+            3>&1 1>&2 2>&3)
         case "$choice" in
-            1) ./configure_nfs_exports.sh --edit "$default_path" ;;
-            *) break ;;
+            4) ./configure_nfs_exports.sh --edit "$default_path" ;;
+            8) break ;;
         esac
     done
 }


### PR DESCRIPTION
## Summary
- remove references to the obsolete **Enter License** menu option
- adjust README instructions accordingly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880ecf57b7c8328a52a42dc183a7c8b