### PR TITLE
Set perf disable cpupower default

### DIFF
--- a/collection/roles/perf_tuning/README.md
+++ b/collection/roles/perf_tuning/README.md
@@ -15,8 +15,8 @@ recommended in Xinnor blogs (2023-2025) and NVIDIA ConnectX-7 (400 Gbit) docs.
 
 ## Variables
 See `defaults/main.yml` for the full list; most tuning knobs can be disabled or
-altered via inventory variables. Notably, set `perf_disable_cpupower: true` to
-skip adjusting the CPU frequency governor. The `cpupower` tool is available
+altered via inventory variables. By default the CPU governor adjustment is
+disabled; set `perf_disable_cpupower: false` to enable it. The `cpupower` tool is available
 through the `linux-tools` packages on Ubuntu (e.g. `linux-tools-$(uname -r)`).
 The role installs `linux-tools-common` along with the matching
 kernel-specific package automatically.

--- a/collection/roles/perf_tuning/defaults/main.yml
+++ b/collection/roles/perf_tuning/defaults/main.yml
@@ -7,7 +7,7 @@
 perf_disable_mitigations: true         # add Spectre/Meltdown mitigations=off, etc.
 perf_nvme_poll_queues: 4               # echo "options nvme poll_queues=4"
 perf_stop_irqbalance: false            # stop irqbalance
-perf_disable_cpupower: false          # skip cpupower governor adjustment
+perf_disable_cpupower: true           # skip cpupower governor adjustment
 perf_cpu_governor: "performance"       # cpupower governor
 perf_disable_thp: true                 # transparent hugepages=never
 perf_disable_ksm: true


### PR DESCRIPTION
## Summary
- disable cpupower by default in `perf_tuning`
- update README to reflect new default

## Testing
- `ansible-playbook playbooks/perf_tuning.yml --syntax-check`
- `ansible-playbook playbooks/site.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_6881d7bb2eac8328a75613dd637b7bca