### PR TITLE
Add OS-specific xiRAID install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ xiTools is a set of utilities for operating system optimization and automated de
    ./collect_data.sh
    ```
 2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode. Any presets you create in expert mode will also be available here and in the simplified menu. It also allows setting a custom hostname.
-3. To apply the configuration, choose **Install** from the menu.
-   The playbook will run at that point, executing all configured roles. An **Exit** option is available if you want to leave without running the playbook.
+3. To apply the configuration, choose **Install xiRAID Classic** from the menu.
+   The playbook installs xiRAID only and runs the required roles. An **Exit** option is available if you want to leave without running the playbook.
+   On RHEL systems follow the [installation guide](https://xinnor.io/docs/xiRAID-4.3.0/E/en/IG/installing_xiraid_classic_on_rhel.html).
 4. To configure an NFS client on another system, run `sudo ./client_setup.sh`. Root
    privileges are required to install packages, create the mount point and mount
    the exported share. If you only need the client pieces, copy the contents of

--- a/collection/roles/xiraid_classic/defaults/main.yml
+++ b/collection/roles/xiraid_classic/defaults/main.yml
@@ -9,11 +9,19 @@ xiraid_repo_version: "1.3.0-1588"
 # (e.g. `kver.6.8`), so extract those from `ansible_kernel`.
 xiraid_kernel: "{{ ansible_kernel | regex_replace('^(\\d+\\.\\d+).*', '\\1') }}"
 
-# Compose repository package name
-xiraid_repo_pkg: "xiraid-repo_{{ xiraid_repo_version }}.kver.{{ xiraid_kernel }}_amd64.deb"
+# Compose repository package names for Debian (.deb) and RHEL (.rpm)
+xiraid_repo_pkg_deb: "xiraid-repo_{{ xiraid_repo_version }}.kver.{{ xiraid_kernel }}_amd64.deb"
+xiraid_repo_pkg_rpm: "xiraid-repo-{{ xiraid_repo_version }}.kver.{{ xiraid_kernel }}.noarch.rpm"
 
-# Base URL to Xinnor repository (multi-pack works for 20.04/22.04/24.04)
-xiraid_repo_url_base: "https://pkg.xinnor.io/repository/Repository/xiraid/ubuntu/multi-pack"
+# Select appropriate package based on OS family
+xiraid_repo_pkg: "{{ xiraid_repo_pkg_deb if ansible_os_family == 'Debian' else xiraid_repo_pkg_rpm }}"
+
+# Base URLs to Xinnor repository for Ubuntu and RHEL
+xiraid_repo_url_base_deb: "https://pkg.xinnor.io/repository/Repository/xiraid/ubuntu/multi-pack"
+xiraid_repo_url_base_rpm: "https://pkg.xinnor.io/repository/Repository/xiraid/el/{{ ansible_distribution_major_version }}"
+
+# Select repository base URL according to OS family
+xiraid_repo_url_base: "{{ xiraid_repo_url_base_deb if ansible_os_family == 'Debian' else xiraid_repo_url_base_rpm }}"
 
 # Full URL of repository package
 xiraid_repo_pkg_url: "{{ xiraid_repo_url_base }}/{{ xiraid_repo_pkg }}"

--- a/collection/roles/xiraid_classic/tasks/main.yml
+++ b/collection/roles/xiraid_classic/tasks/main.yml
@@ -5,11 +5,28 @@
     state: absent
   tags: [xiraid, cleanup]
 
-- name: Ensure kernel headers present (xiRAID DKMS needs them)
+- name: Ensure kernel headers present (Debian)
   ansible.builtin.apt:
     name: "linux-headers-{{ ansible_kernel }}"
     state: present
+  when: ansible_os_family == 'Debian'
   tags: [xiraid, deps]
+
+- name: Install kernel headers on RHEL
+  ansible.builtin.yum:
+    name: "kernel-devel-{{ ansible_kernel }}"
+    state: present
+  when: ansible_os_family == 'RedHat'
+  tags: [xiraid, deps]
+
+- name: Enable CodeReady Builder and install EPEL on RHEL
+  ansible.builtin.shell: |
+    subscription-manager repos --enable codeready-builder-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms
+    dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+  args:
+    warn: false
+  when: ansible_os_family == 'RedHat'
+  tags: [xiraid, repo]
 
 - name: Remove any existing xiRAID repo package before download
   ansible.builtin.file:
@@ -26,24 +43,42 @@
   register: xiraid_repo_dl
   tags: [xiraid, download]
 
-- name: Install xiRAID repo package
+- name: Install xiRAID repo package (Debian)
   ansible.builtin.apt:
     deb: "/tmp/{{ xiraid_repo_pkg }}"
     state: present
-  when: xiraid_repo_dl.changed
+  when: ansible_os_family == 'Debian' and xiraid_repo_dl.changed
+  register: xiraid_repo_added
+  tags: [xiraid, repo]
+
+- name: Install xiRAID repo package (RHEL)
+  ansible.builtin.yum:
+    name: "/tmp/{{ xiraid_repo_pkg }}"
+    state: present
+  when: ansible_os_family == 'RedHat' and xiraid_repo_dl.changed
   register: xiraid_repo_added
   tags: [xiraid, repo]
 
 - name: Update apt cache
   ansible.builtin.apt:
     update_cache: true
+  when: ansible_os_family == 'Debian'
   tags: [xiraid, install]
 
-- name: Install xiRAID core package
+- name: Install xiRAID core package (Debian)
   ansible.builtin.command:
     cmd: "apt-get install --reinstall -y {{ xiraid_packages | join(' ') }}"
+  when: ansible_os_family == 'Debian'
   register: xiraid_pkgs
   changed_when: false
+  tags: [xiraid, install]
+
+- name: Install xiRAID core package (RHEL)
+  ansible.builtin.yum:
+    name: "{{ xiraid_packages }}"
+    state: present
+  when: ansible_os_family == 'RedHat'
+  register: xiraid_pkgs
   tags: [xiraid, install]
 
 - name: Accept xiRAID EULA

--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -244,7 +244,7 @@ choose_preset() {
 while true; do
     choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 15 70 8 \
         1 "Enter Systems" \
-        2 "Install" \
+        2 "Install xiRAID Classic" \
         3 "Performance Tuning" \
         4 "Collect Data" \
         5 "Exit" \

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -134,7 +134,7 @@ configure_nfs_shares() {
             3 "Configure RAID" \
             4 "Edit NFS Exports" \
             5 "Git Repository Configuration" \
-            6 "Install" \
+            6 "Install xiRAID Classic" \
             7 "Exit" \
             8 "Presets" \
             3>&1 1>&2 2>&3)
@@ -371,7 +371,7 @@ while true; do
         3 "Configure RAID" \
         4 "Edit NFS Exports" \
         5 "Git Repository Configuration" \
-        6 "Install" \
+        6 "Install xiRAID Classic" \
         7 "Performance Tuning" \
         8 "Collect Data" \
         9 "Exit" \


### PR DESCRIPTION
## Summary
- rename menu option to **Install xiRAID Classic**
- install xiRAID only
- configure xiRAID role for both Debian and RHEL
- update README with RHEL install link

## Testing
- `ansible-playbook --syntax-check playbooks/site.yml`
- `shellcheck simple_menu.sh startup_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_6881ebc16c4083289473c00b3d226d6c