### PR TITLE
Remove license check for xiRAID Classic install

### DIFF
--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -253,7 +253,7 @@ while true; do
     case "$choice" in
         1) enter_systems ;;
         2)
-            if check_license && check_remove_xiraid && confirm_playbook "playbooks/site.yml"; then
+            if check_remove_xiraid && confirm_playbook "playbooks/site.yml"; then
                 run_playbook "playbooks/site.yml" "inventories/lab.ini"
                 chmod +x post_install_menu.sh
                 ./post_install_menu.sh

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -384,7 +384,7 @@ while true; do
         4) edit_nfs_exports ;;
         5) configure_git_repo ;;
         6)
-            if check_license && check_remove_xiraid && confirm_playbook "playbooks/site.yml"; then
+            if check_remove_xiraid && confirm_playbook "playbooks/site.yml"; then
                 run_playbook "playbooks/site.yml"
                 chmod +x post_install_menu.sh
                 ./post_install_menu.sh


### PR DESCRIPTION
## Summary
- remove license file validation from installation step

## Testing
- `bash -n simple_menu.sh startup_menu.sh`
- `shellcheck simple_menu.sh startup_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_6881f0f08000832886870a2837f74e1f