### PR TITLE
Fix EPEL install task

### DIFF
--- a/collection/roles/xiraid_classic/tasks/main.yml
+++ b/collection/roles/xiraid_classic/tasks/main.yml
@@ -23,8 +23,6 @@
   ansible.builtin.shell: |
     subscription-manager repos --enable codeready-builder-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms
     dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
-  args:
-    warn: false
   when: ansible_os_family == 'RedHat'
   tags: [xiraid, repo]
 


### PR DESCRIPTION
## Summary
- remove unsupported `warn` argument from RHEL shell task

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881f6d75b348328bfc105d5e72ca8f3