### PR TITLE
Fix kernel-specific repo URL

### DIFF
--- a/collection/roles/xiraid_classic/defaults/main.yml
+++ b/collection/roles/xiraid_classic/defaults/main.yml
@@ -18,7 +18,7 @@ xiraid_repo_pkg: "{{ xiraid_repo_pkg_deb if ansible_os_family == 'Debian' else x
 
 # Base URLs to Xinnor repository for Ubuntu and RHEL
 xiraid_repo_url_base_deb: "https://pkg.xinnor.io/repository/Repository/xiraid/ubuntu/multi-pack"
-xiraid_repo_url_base_rpm: "https://pkg.xinnor.io/repository/Repository/xiraid/el/{{ ansible_distribution_major_version }}"
+xiraid_repo_url_base_rpm: "https://pkg.xinnor.io/repository/Repository/xiraid/el/{{ ansible_distribution_major_version }}/kver-{{ xiraid_kernel }}"
 
 # Select repository base URL according to OS family
 xiraid_repo_url_base: "{{ xiraid_repo_url_base_deb if ansible_os_family == 'Debian' else xiraid_repo_url_base_rpm }}"


### PR DESCRIPTION
## Summary
- adjust base URL to include kernel subdirectory in RPM repo

## Testing
- `curl -L -I https://pkg.xinnor.io/repository/Repository/xiraid/el/9/kver-5.14/xiraid-repo-1.3.0-1588.kver.5.14.noarch.rpm`


------
https://chatgpt.com/codex/tasks/task_e_6881f9ad93d483288e3c27c2ebe38cc3