### PR TITLE
Fix xiRAID repo install on unsigned RPM

### DIFF
--- a/collection/roles/xiraid_classic/tasks/main.yml
+++ b/collection/roles/xiraid_classic/tasks/main.yml
@@ -53,6 +53,7 @@
   ansible.builtin.yum:
     name: "/tmp/{{ xiraid_repo_pkg }}"
     state: present
+    disable_gpg_check: true
   when: ansible_os_family == 'RedHat' and xiraid_repo_dl.changed
   register: xiraid_repo_added
   tags: [xiraid, repo]


### PR DESCRIPTION
## Summary
- disable GPG signature verification when installing the xiRAID repo RPM on RHEL systems

## Testing
- `ansible-playbook playbooks/xiraid_only.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_6881feca7dc483289302b954716bfa63