### PR TITLE
Remove post-install menu

### DIFF
--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -255,9 +255,7 @@ while true; do
         2)
             if check_remove_xiraid && confirm_playbook "playbooks/xiraid_only.yml"; then
                 run_playbook "playbooks/xiraid_only.yml" "inventories/lab.ini"
-                chmod +x post_install_menu.sh
-                ./post_install_menu.sh
-                exit 0
+                whiptail --msgbox "Installation completed. Returning to main menu." 8 60 || true
             fi
             ;;
         3) run_perf_tuning ;;

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -386,9 +386,7 @@ while true; do
         6)
             if check_remove_xiraid && confirm_playbook "playbooks/xiraid_only.yml"; then
                 run_playbook "playbooks/xiraid_only.yml"
-                chmod +x post_install_menu.sh
-                ./post_install_menu.sh
-                exit 0
+                whiptail --msgbox "Installation completed. Returning to main menu." 8 60 || true
             fi
             ;;
         7) run_perf_tuning ;;


### PR DESCRIPTION
## Summary
- skip calling `post_install_menu.sh` after installation
- return to the main menu instead of exiting

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6882029af5048328aa20e1262f360ac2