### PR TITLE
Improve xiRAID cleanup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ xiTools is a set of utilities for operating system optimization and automated de
    This now uses `playbooks/xiraid_only.yml` to install xiRAID Classic without applying
    additional roles. An **Exit** option is available if you want to leave without running the playbook.
    On RHEL systems follow the [installation guide](https://xinnor.io/docs/xiRAID-4.3.0/E/en/IG/installing_xiraid_classic_on_rhel.html).
+   Before running the playbook make sure any previous xiRAID packages are removed.
+   On RHEL, RHEL-based or Oracle Linux systems run:
+   ```bash
+   sudo dnf remove xiraid-core && sudo dnf autoremove
+   sudo dnf remove xiraid-repo
+   ```
+   On Ubuntu or Proxmox use:
+   ```bash
+   sudo apt remove xiraid-appimage xiraid-core xiraid-kmod
+   sudo apt remove xiraid-repo
+   sudo apt autoremove
+   ```
 4. To configure an NFS client on another system, run `sudo ./client_setup.sh`. Root
    privileges are required to install packages, create the mount point and mount
    the exported share. If you only need the client pieces, copy the contents of

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -223,14 +223,27 @@ run_perf_tuning() {
 
 # Check for installed xiRAID packages and optionally remove them
 check_remove_xiraid() {
-    local pkgs found repo_status log=/tmp/xiraid_remove.log
-    pkgs=$(dpkg-query -W -f='${Package} ${Status}\n' 'xiraid*' 2>/dev/null | \
-        awk '$4=="installed"{print $1}')
-    repo_status=$(pkg_status xiraid-repo)
+    local pkgs found repo_status log=/tmp/xiraid_remove.log pkg_mgr
+
+    if command -v dpkg-query >/dev/null 2>&1; then
+        pkgs=$(dpkg-query -W -f='${Package} ${Status}\n' 'xiraid*' 2>/dev/null | awk '$4=="installed"{print $1}')
+        repo_status=$(pkg_status xiraid-repo)
+        pkg_mgr="apt"
+    else
+        pkgs=$(rpm -qa 'xiraid*' 2>/dev/null)
+        repo_status=$(rpm -q xiraid-repo 2>/dev/null || true)
+        pkg_mgr="dnf"
+    fi
+
     [ -n "$repo_status" ] && echo "xiraid-repo: $repo_status"
     rm -f "$log"
+
     if [ -z "$pkgs" ]; then
-        sudo apt-get autoremove -y -qq --allow-change-held-packages >"$log" 2>&1 || true
+        if [ "$pkg_mgr" = "apt" ]; then
+            sudo apt-get autoremove -y -qq --allow-change-held-packages >"$log" 2>&1 || true
+        else
+            sudo dnf autoremove -y >"$log" 2>&1 || true
+        fi
         if [ -s "$log" ]; then
             msg="Obsolete packages removed"
             if [ -n "$WHIPTAIL" ]; then
@@ -248,13 +261,24 @@ check_remove_xiraid() {
         return 1
     fi
 
-    if sudo apt-get purge -y -qq --allow-change-held-packages $pkgs >"$log" 2>&1 \
-        && sudo apt-get autoremove -y -qq --allow-change-held-packages >>"$log" 2>&1 \
-        && sudo rm -rf /etc/xiraid >>"$log" 2>&1; then
-        msg="xiRAID packages removed successfully"
+    if [ "$pkg_mgr" = "apt" ]; then
+        if sudo apt-get purge -y -qq --allow-change-held-packages "$pkgs" >"$log" 2>&1 \
+            && sudo apt-get autoremove -y -qq --allow-change-held-packages >>"$log" 2>&1 \
+            && sudo rm -rf /etc/xiraid >>"$log" 2>&1; then
+            msg="xiRAID packages removed successfully"
+        else
+            msg="Errors occurred during removal. See $log for details"
+        fi
     else
-        msg="Errors occurred during removal. See $log for details"
+        if sudo dnf remove -y "$pkgs" >"$log" 2>&1 \
+            && sudo dnf autoremove -y >>"$log" 2>&1 \
+            && sudo rm -rf /etc/xiraid >>"$log" 2>&1; then
+            msg="xiRAID packages removed successfully"
+        else
+            msg="Errors occurred during removal. See $log for details"
+        fi
     fi
+
     if [ -n "$WHIPTAIL" ]; then
         whiptail --msgbox "$msg" 8 60
     else


### PR DESCRIPTION
## Summary
- document removing old xiRAID packages prior to install
- extend `check_remove_xiraid` to work on both apt and dnf systems

## Testing
- `shellcheck simple_menu.sh startup_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_688206c0ec3c83288440192283a78613