### PR TITLE
Preserve /etc/xiraid during install

### DIFF
--- a/collection/roles/xiraid_classic/tasks/main.yml
+++ b/collection/roles/xiraid_classic/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Remove legacy /etc/xiraid directory if present
-  ansible.builtin.file:
-    path: /etc/xiraid
-    state: absent
-  tags: [xiraid, cleanup]
 
 - name: Ensure kernel headers present (Debian)
   ansible.builtin.apt:

--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -118,16 +118,14 @@ check_remove_xiraid() {
 
     if [ "$pkg_mgr" = "apt" ]; then
         if sudo apt-get purge -y -qq --allow-change-held-packages "$pkgs" >"$log" 2>&1 \
-            && sudo apt-get autoremove -y -qq --allow-change-held-packages >>"$log" 2>&1 \
-            && sudo rm -rf /etc/xiraid >>"$log" 2>&1; then
+            && sudo apt-get autoremove -y -qq --allow-change-held-packages >>"$log" 2>&1; then
             msg="xiRAID packages removed successfully"
         else
             msg="Errors occurred during removal. See $log for details"
         fi
     else
         if sudo dnf remove -y "$pkgs" >"$log" 2>&1 \
-            && sudo dnf autoremove -y >>"$log" 2>&1 \
-            && sudo rm -rf /etc/xiraid >>"$log" 2>&1; then
+            && sudo dnf autoremove -y >>"$log" 2>&1; then
             msg="xiRAID packages removed successfully"
         else
             msg="Errors occurred during removal. See $log for details"

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -263,16 +263,14 @@ check_remove_xiraid() {
 
     if [ "$pkg_mgr" = "apt" ]; then
         if sudo apt-get purge -y -qq --allow-change-held-packages "$pkgs" >"$log" 2>&1 \
-            && sudo apt-get autoremove -y -qq --allow-change-held-packages >>"$log" 2>&1 \
-            && sudo rm -rf /etc/xiraid >>"$log" 2>&1; then
+            && sudo apt-get autoremove -y -qq --allow-change-held-packages >>"$log" 2>&1; then
             msg="xiRAID packages removed successfully"
         else
             msg="Errors occurred during removal. See $log for details"
         fi
     else
         if sudo dnf remove -y "$pkgs" >"$log" 2>&1 \
-            && sudo dnf autoremove -y >>"$log" 2>&1 \
-            && sudo rm -rf /etc/xiraid >>"$log" 2>&1; then
+            && sudo dnf autoremove -y >>"$log" 2>&1; then
             msg="xiRAID packages removed successfully"
         else
             msg="Errors occurred during removal. See $log for details"


### PR DESCRIPTION
## Summary
- stop deleting `/etc/xiraid` in the `xiraid_classic` role
- avoid wiping `/etc/xiraid` in cleanup steps of the menu scripts

## Testing
- `shellcheck simple_menu.sh startup_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_68820f470d988328adc935e79b2e2e41