### PR TITLE
Display hwkey output instead of saving

### DIFF
--- a/collect_hw_keys.sh
+++ b/collect_hw_keys.sh
@@ -45,7 +45,8 @@ main() {
     nvme list > "$tmp/nvme_list.txt" 2>&1 || true
     lspci > "$tmp/lspci.txt" 2>&1 || true
     [ -x ./hwkey ] || chmod +x ./hwkey
-    ./hwkey > "$tmp/hwkey.txt" 2>&1 || true
+    echo "Hardware key:"
+    ./hwkey 2>&1 || true
 
     # NUMA node for each disk
     for dev in $(lsblk -ndo NAME,TYPE | awk '$2=="disk"{print $1}'); do


### PR DESCRIPTION
## Summary
- show hwkey output directly when collecting hardware info

## Testing
- `shellcheck collect_hw_keys.sh`


------
https://chatgpt.com/codex/tasks/task_e_68821afd91188328a46e93e2a81458eb