### PR TITLE
Use xicli to display hardware keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ xiTools is a set of utilities for operating system optimization and automated de
 
 1. Run `prepare_system.sh` on the target host (use the `-e` option for expert mode). Use `-u` to update the repository without launching any menus. The script now automatically detects Ubuntu or RedHat-based distributions and installs required packages (`yq` version 4, `whiptail`/`newt`, `ansible`, etc.) using the appropriate package manager before cloning the repository.
    The script immediately launches a simplified start menu in default mode to choose a preset. Use `-e` to access the full interactive menu with additional options such as updating the repository or saving the current configuration as a new preset.
-   Both menus now include a **Collect HW Keys** option for gathering system information into a tar archive and uploading it via `transfer.sh`. The upload server is configured automatically and listens on port 8080. You can override it by setting the `TRANSFER_SERVER` environment variable if needed.
+   Both menus now include a **Collect HW Keys** option that displays hardware
+   keys retrieved using `xicli license show`. The script shows each key in the
+   format `hostname : hwkey` inside a text dialog.
 
    Example:
    ```bash
-   export TRANSFER_SERVER="http://178.253.23.152:8080"
    ./collect_hw_keys.sh
    ```
 2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode. Any presets you create in expert mode will also be available here and in the simplified menu. It also allows setting a custom hostname.

--- a/collect_hw_keys.sh
+++ b/collect_hw_keys.sh
@@ -1,10 +1,28 @@
 #!/usr/bin/env bash
-# Collect hardware keys and system data, then upload via transfer.sh
+# Display xiRAID hardware keys in the terminal UI
 set -euo pipefail
 
-main() {
-    local cfg tmp archive server
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
+show_hwkeys() {
+    local out="$TMP_DIR/hwkeys"
+
+    if xicli license show >"$out" 2>&1; then
+        grep -i hwkey "$out" | sed "s/^/$(hostname) : /" >"${out}.fmt"
+        mv "${out}.fmt" "$out"
+    else
+        echo "Failed to run xicli license show" >"$out"
+    fi
+
+    if command -v whiptail >/dev/null 2>&1; then
+        whiptail --title "Hardware Keys" --textbox "$out" 20 70
+    else
+        cat "$out"
+    fi
+}
+
+main() {
     while [ $# -gt 0 ]; do
         case $1 in
             -h|--help)
@@ -19,38 +37,7 @@ main() {
         esac
     done
 
-    cfg="hwkeys"
-    tmp=$(mktemp -d)
-
-    lsblk -o NAME,SIZE,TYPE,MOUNTPOINT > "$tmp/lsblk.txt"
-    cat /proc/mdstat > "$tmp/mdstat.txt" 2>/dev/null || true
-    pvs > "$tmp/pvs.txt" 2>&1 || true
-    nvme list > "$tmp/nvme_list.txt" 2>&1 || true
-    lspci > "$tmp/lspci.txt" 2>&1 || true
-    echo "Hardware keys:"
-    rdcli license show | grep hwkey | tee "$tmp/hwkey.txt" || true
-
-    # NUMA node for each disk
-    for dev in $(lsblk -ndo NAME,TYPE | awk '$2=="disk"{print $1}'); do
-        node_file="/sys/block/$dev/device/numa_node"
-        if [ -f "$node_file" ]; then
-            echo "$dev $(cat "$node_file")" >> "$tmp/numa_nodes.txt"
-        else
-            echo "$dev unknown" >> "$tmp/numa_nodes.txt"
-        fi
-    done
-
-    archive="/tmp/${cfg}.tgz"
-    tar czf "$archive" -C "$tmp" .
-
-    server=${TRANSFER_SERVER:-"http://178.253.23.152:8080"}
-
-    if ! curl --fail --upload-file "$archive" "$server/$(basename "$archive")"; then
-        echo "Warning: transfer.sh upload failed" >&2
-    fi
-
-    rm -rf "$tmp"
-    echo "Archive created: $archive"
+    show_hwkeys
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- update `collect_hw_keys.sh` to use `xicli license show`
- remove data archiving and uploading
- show hardware keys in a whiptail dialog or print to stdout
- update README description

## Testing
- `bash -n collect_hw_keys.sh`
- `shellcheck collect_hw_keys.sh`
- `apt-get update`
- `apt-get install -y shellcheck`

------
https://chatgpt.com/codex/tasks/task_e_688221bf562c83289cf4a80cfa3f6779