### PR TITLE
Collect hwkey from inventory hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ xiTools is a set of utilities for operating system optimization and automated de
 1. Run `prepare_system.sh` on the target host (use the `-e` option for expert mode). Use `-u` to update the repository without launching any menus. The script now automatically detects Ubuntu or RedHat-based distributions and installs required packages (`yq` version 4, `whiptail`/`newt`, `ansible`, etc.) using the appropriate package manager before cloning the repository.
    The script immediately launches a simplified start menu in default mode to choose a preset. Use `-e` to access the full interactive menu with additional options such as updating the repository or saving the current configuration as a new preset.
    Both menus now include a **Collect HW Keys** option that displays hardware
-   keys retrieved using `xicli license show`. The script shows each key in the
-   format `hostname : hwkey` inside a text dialog.
+   keys gathered from all systems listed in the Ansible inventory using
+   `xicli license show`. Each key is shown in the format
+   `hostname : hwkey` inside a text dialog.
 
    Example:
    ```bash
-   ./collect_hw_keys.sh
+   ./collect_hw_keys.sh [-i path/to/inventory]
    ```
 2. Execute `startup_menu.sh` separately if you need the complete configuration menu outside of the expert mode. Any presets you create in expert mode will also be available here and in the simplified menu. It also allows setting a custom hostname.
 3. To apply the configuration, choose **Install xiRAID Classic** from the menu.


### PR DESCRIPTION
## Summary
- collect hardware keys using ansible on hosts in `inventories/lab.ini`
- update README to describe inventory option

## Testing
- `bash -n collect_hw_keys.sh`

------
https://chatgpt.com/codex/tasks/task_e_688227a0a7f48328b9d7636cc43c66a0