### PR TITLE
Add RAID preset feature

### DIFF
--- a/playbooks/raid_preset.yml
+++ b/playbooks/raid_preset.yml
@@ -1,0 +1,6 @@
+---
+- name: Create RAID preset
+  hosts: storage_nodes
+  gather_facts: true
+  roles:
+    - role: raid_fs


### PR DESCRIPTION
## Summary
- rename menu item to **RAID Preset**
- add `raid_preset` function for prompting RAID parameters
- create `playbooks/raid_preset.yml` to configure RAID arrays across inventory

## Testing
- `bash -n startup_menu.sh`
- `bash -n simple_menu.sh`
- `ansible-playbook --syntax-check playbooks/raid_preset.yml -i inventories/lab.ini`


------
https://chatgpt.com/codex/tasks/task_e_68822a2c56608328849329e38e9ae7ab