### PR TITLE
Remove license application from raid_fs

### DIFF
--- a/collection/roles/raid_fs/README.md
+++ b/collection/roles/raid_fs/README.md
@@ -4,7 +4,6 @@ Creates xiRAID arrays and tuned XFS filesystems as per Xinnor NFS RDMA blog.
 ## Variables
 * `xiraid_arrays` – list of array definitions (name, level, devices, strip size, parity).
 * `xfs_filesystems` – list defining data/log device pairs, mount point, mkfs params.
-* `xiraid_license_path` – path to license file applied before arrays are created.
 * `xiraid_force_metadata` – when `true` add `--force_metadata` to array creation.
 * `xfs_force_mkfs` – when `true` always run `mkfs.xfs` even if the filesystem and label already match. By default this is `true`, so filesystems are recreated on every run.
 

--- a/collection/roles/raid_fs/defaults/main.yml
+++ b/collection/roles/raid_fs/defaults/main.yml
@@ -2,7 +2,6 @@
 #
 # The actual RAID array and filesystem configuration is stored here so
 # interactive helper scripts can modify it directly.
-xiraid_license_path: "/tmp/license"
 
 # Whether to pass `--force_metadata` when creating arrays
 # Set to `false` if metadata should not be overwritten

--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: Apply xiRAID license
-  ansible.builtin.command: "xicli license update -p {{ xiraid_license_path }}"
-  changed_when: false
-  tags: [raid_fs, raid]
 
 - name: Build list of xiRAID device paths
   ansible.builtin.set_fact:

--- a/presets/default/raid_fs.yml
+++ b/presets/default/raid_fs.yml
@@ -2,7 +2,6 @@
 #
 # The actual RAID array and filesystem configuration is stored here so
 # interactive helper scripts can modify it directly.
-xiraid_license_path: "/tmp/license"
 
 # Whether to pass `--force_metadata` when creating arrays
 # Set to `false` if metadata should not be overwritten

--- a/presets/xinnorVM/raid_fs.yml
+++ b/presets/xinnorVM/raid_fs.yml
@@ -2,7 +2,6 @@
 #
 # The actual RAID array and filesystem configuration is stored here so
 # interactive helper scripts can modify it directly.
-xiraid_license_path: "/tmp/license"
 
 # Whether to pass `--force_metadata` when creating arrays
 # Set to `false` if metadata should not be overwritten


### PR DESCRIPTION
## Summary
- stop updating license in `raid_fs` role
- remove `xiraid_license_path` variable and docs
- clean up presets

## Testing
- `ansible-playbook playbooks/raid_preset.yml --syntax-check`
- `ansible-playbook playbooks/site.yml --syntax-check`
- `ansible-playbook playbooks/xiraid_only.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_68822c26a0908328833b22da87298489