### PR TITLE
Remove mdraid handling from raid_fs role

### DIFF
--- a/collection/roles/raid_fs/README.md
+++ b/collection/roles/raid_fs/README.md
@@ -7,8 +7,6 @@ Creates xiRAID arrays and tuned XFS filesystems as per Xinnor NFS RDMA blog.
 * `xiraid_force_metadata` – when `true` add `--force_metadata` to array creation.
 * `xfs_force_mkfs` – when `true` always run `mkfs.xfs` even if the filesystem and label already match. By default this is `true`, so filesystems are recreated on every run.
 
-This role requires the **mdadm** package to be installed so that any
-leftover Linux MD arrays on xiRAID devices can be stopped and wiped.
 
 All drives referenced by the array and spare pool definitions are
 cleaned using `xicli drive clean -d <device>` (or `--drives`) before

--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -21,12 +21,6 @@
   changed_when: false
   tags: [raid_fs, raid, cleanup]
 
-- name: Ensure mdadm package present
-  ansible.builtin.apt:
-    name: mdadm
-    state: present
-  tags: [raid_fs, raid]
-
 - name: Gather existing spare pools
   ansible.builtin.command: xicli pool show -f json
   register: xiraid_pools
@@ -53,43 +47,6 @@
   when: item.name not in ((existing_pools | default([], true) | json_query('[].name')) | default([], true))
   tags: [raid_fs, raid]
 
-- name: Find active MD RAID arrays
-  ansible.builtin.command: lsblk -ln -o NAME,TYPE | awk '$2 ~ /^raid/ {print "/dev/"$1}'
-  register: mdraid_scan
-  changed_when: false
-  failed_when: false
-  tags: [raid_fs, raid]
-
-- name: Stop leftover MD RAID arrays on xiRAID devices
-  ansible.builtin.shell: |
-    set -e
-    md_devs=$(lsblk -ln -o NAME,TYPE | awk '$2 ~ /^raid/ {print "/dev/"$1}')
-    for md in $md_devs; do
-      [ -n "$(lsblk -nro MOUNTPOINT "$md")" ] && continue
-      comps=$(ls -1 /sys/block/$(basename "$md")/slaves)
-      stop_md=0
-      for c in $comps; do
-        case " {{ xiraid_device_basenames | join(' ') }} " in
-          *" $c "*)
-            stop_md=1
-            ;;
-        esac
-      done
-      if [ "$stop_md" = 1 ]; then
-        mdadm --stop "$md"
-      fi
-      for c in $comps; do
-        case " {{ xiraid_device_basenames | join(' ') }} " in
-          *" $c "*)
-            mdadm --zero-superblock "/dev/$c"
-            ;;
-        esac
-      done
-    done
-  args:
-    executable: /bin/bash
-  changed_when: false
-  tags: [raid_fs, raid]
 
 - name: Gather existing xiRAID arrays (json)
   ansible.builtin.command: xicli raid show -f json


### PR DESCRIPTION
## Summary
- drop tasks that looked for and stopped MD RAID arrays
- remove requirement of mdadm from documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68822f4c92d8832881f54557c49ac166