### PR TITLE
Install jmespath dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ xiTools is a set of utilities for operating system optimization and automated de
    the script will automatically install Ansible packages when needed.
 
 The `prepare_system.sh` script installs dependencies required by the interactive helper scripts. It works on both Ubuntu and RedHat-like systems by selecting `apt`, `dnf`, or `yum` as needed. The helper scripts rely on the [`mikefarah/yq`](https://github.com/mikefarah/yq) binary (v4+). If you encounter errors such as `jq: error: env/1 is not defined`, make sure this version of `yq` is installed by re-running `prepare_system.sh` or installing it manually.
+The playbooks also use Ansible's `json_query` filter, which depends on the
+`jmespath` Python library. Recent updates to `prepare_system.sh` and
+`client_repo/client_setup.sh` automatically install the `python3-jmespath`
+package on systems using `apt`, `dnf`, or `yum`. If you see an error like
+`You need to install "jmespath" prior to running json_query filter`, rerun the
+setup scripts or install the package manually.
 Earlier versions of the RAID configuration script failed with `'//' expects 2 args but there is 1` when no spare pool existed. The script now creates the pool automatically the first time you enter devices.
 You can inspect all `yq` binaries with `which -a yq`. If multiple paths are listed, reorder your `PATH` so `/usr/local/bin/yq` precedes others or remove the older version entirely.
 

--- a/client_repo/client_setup.sh
+++ b/client_repo/client_setup.sh
@@ -61,9 +61,12 @@ run_playbook() {
     if ! command -v ansible-playbook >/dev/null 2>&1; then
         if command -v apt-get >/dev/null 2>&1; then
             apt-get update -y
-            apt-get install -y ansible
+            # Install jmespath to support the json_query filter used by
+            # the playbooks that may run from this script
+            apt-get install -y ansible python3-jmespath
         elif command -v yum >/dev/null 2>&1; then
-            yum install -y ansible
+            # Ensure python3-jmespath is present for json_query filter
+            yum install -y ansible python3-jmespath
         else
             echo "Ansible not found and automatic installation is unsupported." >&2
             return 1

--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -20,11 +20,16 @@ done
 if [ "$UPDATE_ONLY" -eq 0 ]; then
     if command -v apt-get >/dev/null 2>&1; then
         sudo apt-get update -y
-        sudo apt-get install -y ansible git whiptail dialog wget
+        # Install Ansible and supporting utilities. The json_query filter used
+        # throughout the playbooks requires the jmespath Python library which is
+        # packaged as python3-jmespath on Debian/Ubuntu systems.
+        sudo apt-get install -y ansible git whiptail dialog wget python3-jmespath
     elif command -v dnf >/dev/null 2>&1; then
-        sudo dnf install -y ansible git newt dialog wget
+        # Ensure jmespath is available for json_query filter
+        sudo dnf install -y ansible git newt dialog wget python3-jmespath
     elif command -v yum >/dev/null 2>&1; then
-        sudo yum install -y ansible git newt dialog wget
+        # Ensure jmespath is available for json_query filter
+        sudo yum install -y ansible git newt dialog wget python3-jmespath
     else
         echo "Unsupported package manager. Install ansible, git, whiptail/newt, dialog, and wget manually." >&2
         exit 1


### PR DESCRIPTION
## Summary
- add python3-jmespath installation to setup scripts
- ensure client setup also installs jmespath
- document jmespath dependency in README

## Testing
- `bash -n prepare_system.sh`
- `bash -n client_repo/client_setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6882333075c08328902e878848dcb00d