### PR TITLE
Add optional RAID parameters menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ xiTools is a set of utilities for operating system optimization and automated de
 ## Getting started
 
 1. Run `prepare_system.sh` on the target host (use the `-e` option for expert mode). Use `-u` to update the repository without launching any menus. The script now automatically detects Ubuntu or RedHat-based distributions and installs required packages (`yq` version 4, `whiptail`/`newt`, `ansible`, etc.) using the appropriate package manager before cloning the repository.
-   The script immediately launches a simplified start menu in default mode to choose a preset. Use `-e` to access the full interactive menu with additional options such as updating the repository or saving the current configuration as a new preset.
+   The script immediately launches a simplified start menu in default mode to choose a preset. Use `-e` to access the full interactive menu with additional options such as updating the repository or saving the current configuration as a new preset. When creating a RAID preset the menu now displays a list of optional `xicli raid create` parameters and lets you enter any desired options.
    Both menus now include a **Collect HW Keys** option that displays hardware
    keys gathered from all systems listed in the Ansible inventory using
    `xicli license show`. Each key is shown in the format

--- a/collection/roles/raid_fs/tasks/create_array.yml
+++ b/collection/roles/raid_fs/tasks/create_array.yml
@@ -12,6 +12,7 @@
   ansible.builtin.command: >-
     xicli raid create -n {{ item.name }} -l {{ item.level }}
     -d {{ _devlist }} -ss {{ item.strip_size_kb }}
+    {% if item.extra_opts is defined %}{{ item.extra_opts }} {% endif %}
     {% if item.spare_pool is defined %}-sp {{ item.spare_pool }}{% endif %}
     {% if xiraid_force_metadata | bool %}--force_metadata{% endif %}
   register: raid_create

--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -93,12 +93,21 @@ raid_preset() {
     set -e
     [ $status -ne 0 ] && return
 
+    local extra_opts="" input
+    local opts="--adaptive_merge --single_run --block_size --cpu_allowed --init_prio --merge_write_enabled --merge_read_enabled --merge_read_max --merge_read_wait --merge_write_max --merge_write_wait --memory_limit --memory_prealloc --recon_prio --request_limit --restripe_prio --sdc_prio --sched_enabled --sparepool --force_metadata --trim --no_trim"
+    whiptail --title "Optional RAID Parameters" --scrolltext --msgbox "Supported optional parameters:\n${opts}\nRefer to docs for details." 20 70 || true
+    input=$(whiptail --inputbox "Enter optional parameters" 10 70 3>&1 1>&2 2>&3)
+    extra_opts="$input"
+
     var_file="$TMP_DIR/raid_vars.yml"
     {
         echo "xiraid_arrays:"
         echo "  - name: ${name}"
         echo "    level: ${level}"
         echo "    strip_size_kb: ${stripe}"
+        if [ -n "$extra_opts" ]; then
+            echo "    extra_opts: \"$extra_opts\""
+        fi
         echo "    devices:"
         for dev in $devices; do
             echo "      - $dev"

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -183,12 +183,21 @@ raid_preset() {
     set -e
     [ $status -ne 0 ] && return
 
+    local extra_opts="" input
+    local opts="--adaptive_merge --single_run --block_size --cpu_allowed --init_prio --merge_write_enabled --merge_read_enabled --merge_read_max --merge_read_wait --merge_write_max --merge_write_wait --memory_limit --memory_prealloc --recon_prio --request_limit --restripe_prio --sdc_prio --sched_enabled --sparepool --force_metadata --trim --no_trim"
+    whiptail --title "Optional RAID Parameters" --scrolltext --msgbox "Supported optional parameters:\n${opts}\nRefer to docs for details." 20 70 || true
+    input=$(whiptail --inputbox "Enter optional parameters" 10 70 3>&1 1>&2 2>&3)
+    extra_opts="$input"
+
     var_file="$TMP_DIR/raid_vars.yml"
     {
         echo "xiraid_arrays:"
         echo "  - name: ${name}"
         echo "    level: ${level}"
         echo "    strip_size_kb: ${stripe}"
+        if [ -n "$extra_opts" ]; then
+            echo "    extra_opts: \"$extra_opts\""
+        fi
         echo "    devices:"
         for dev in $devices; do
             echo "      - $dev"


### PR DESCRIPTION
## Summary
- show optional parameters available for `xicli raid create`
- allow entering extra options when creating RAID presets
- include extra options when running playbook

## Testing
- `bash -n simple_menu.sh`
- `bash -n startup_menu.sh`
- `bash -n configure_raid.sh`
- `ansible-playbook playbooks/raid_preset.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_68823662f2848328943a54b44ed96b1b