### PR TITLE
Add Ansible system cleanup role

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ xiTools is a set of utilities for operating system optimization and automated de
    sudo apt remove xiraid-repo
    sudo apt autoremove
    ```
-4. To configure an NFS client on another system, run `sudo ./client_setup.sh`. Root
+
+4. Choose **System Cleanup** to remove xiRAID and tuning packages from all hosts. This runs `playbooks/system_cleanup.yml` and keeps your inventory intact.
+
+5. To configure an NFS client on another system, run `sudo ./client_setup.sh`. Root
    privileges are required to install packages, create the mount point and mount
    the exported share. If you only need the client pieces, copy the contents of
    the `client_repo` directory into a separate repository and run the script

--- a/collection/roles/system_cleanup/README.md
+++ b/collection/roles/system_cleanup/README.md
@@ -1,0 +1,15 @@
+# Role: system_cleanup
+
+Removes xiRAID packages, performance tuning utilities and matching kernel headers from storage nodes.
+
+## Features
+* Purges `xiraid*` packages and repository files.
+* Uninstalls optional performance tuning packages.
+* Removes kernel headers for the running kernel.
+
+## Example
+```yaml
+- hosts: storage_nodes
+  roles:
+    - system_cleanup
+```

--- a/collection/roles/system_cleanup/tasks/main.yml
+++ b/collection/roles/system_cleanup/tasks/main.yml
@@ -1,0 +1,84 @@
+---
+- name: Remove xiRAID packages on Debian/Ubuntu
+  ansible.builtin.apt:
+    name: "xiraid*"
+    state: absent
+    purge: yes
+    autoremove: yes
+  when: ansible_os_family == 'Debian'
+  tags: [xiraid, cleanup]
+
+- name: Remove xiRAID packages on RHEL
+  ansible.builtin.yum:
+    name: "xiraid*"
+    state: absent
+  when: ansible_os_family == 'RedHat'
+  register: xiraid_removed
+  tags: [xiraid, cleanup]
+
+- name: Autoremove packages on RHEL
+  ansible.builtin.command: dnf autoremove -y
+  when:
+    - ansible_os_family == 'RedHat'
+    - xiraid_removed is changed
+  tags: [cleanup]
+
+- name: Remove xiRAID repo package
+  ansible.builtin.package:
+    name: xiraid-repo
+    state: absent
+  tags: [xiraid, cleanup]
+
+- name: Remove performance tuning packages on Debian
+  ansible.builtin.apt:
+    name:
+      - cpufrequtils
+      - linux-tools-common
+      - "linux-tools-{{ ansible_kernel }}"
+      - tuned
+    state: absent
+    purge: yes
+    autoremove: yes
+  when: ansible_os_family == 'Debian'
+  tags: [perf, cleanup]
+
+- name: Remove performance tuning packages on RHEL
+  ansible.builtin.yum:
+    name:
+      - tuned
+      - kernel-tools
+    state: absent
+  when: ansible_os_family == 'RedHat'
+  register: perf_removed
+  tags: [perf, cleanup]
+
+- name: Autoremove performance packages on RHEL
+  ansible.builtin.command: dnf autoremove -y
+  when:
+    - ansible_os_family == 'RedHat'
+    - perf_removed is changed
+  tags: [cleanup]
+
+- name: Remove kernel headers on Debian
+  ansible.builtin.apt:
+    name: "linux-headers-{{ ansible_kernel }}"
+    state: absent
+    purge: yes
+    autoremove: yes
+  when: ansible_os_family == 'Debian'
+  tags: [kernel, cleanup]
+
+- name: Remove kernel headers on RHEL
+  ansible.builtin.yum:
+    name: "kernel-devel-{{ ansible_kernel }}"
+    state: absent
+  when: ansible_os_family == 'RedHat'
+  register: headers_removed
+  tags: [kernel, cleanup]
+
+- name: Autoremove kernel headers on RHEL
+  ansible.builtin.command: dnf autoremove -y
+  when:
+    - ansible_os_family == 'RedHat'
+    - headers_removed is changed
+  tags: [cleanup]

--- a/playbooks/system_cleanup.yml
+++ b/playbooks/system_cleanup.yml
@@ -1,0 +1,6 @@
+---
+- name: Cleanup xiRAID and tuning packages
+  hosts: storage_nodes
+  gather_facts: true
+  roles:
+    - role: system_cleanup

--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -405,10 +405,10 @@ remove_kernel_headers() {
 
 # Clean systems, xiRAID and performance tuning packages
 cleanup_system() {
-    clear_inventory
-    check_remove_xiraid || true
-    remove_perf_packages
-    remove_kernel_headers
+    local pb="$REPO_DIR/playbooks/system_cleanup.yml"
+    if confirm_playbook; then
+        run_playbook "$pb" "inventories/lab.ini"
+    fi
 }
 
 while true; do

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -498,12 +498,11 @@ remove_kernel_headers() {
 
 # Clean systems, xiRAID and performance tuning packages
 cleanup_system() {
-    clear_inventory
-    check_remove_xiraid || true
-    remove_perf_packages
-    remove_kernel_headers
+    local pb="$REPO_DIR/playbooks/system_cleanup.yml"
+    if confirm_playbook "$pb"; then
+        run_playbook "$pb" "inventories/lab.ini"
+    fi
 }
-
 # Main menu loop
 while true; do
     choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 20 70 17 \


### PR DESCRIPTION
## Summary
- add `system_cleanup` role with tasks to remove xiRAID, tuning packages and kernel headers
- provide new `playbooks/system_cleanup.yml`
- update simple and startup menus to run the cleanup playbook
- document cleanup option in README

## Testing
- `ansible-playbook playbooks/system_cleanup.yml --syntax-check`
- `bash -n simple_menu.sh startup_menu.sh`
- `apt-get install -y ansible`

------
https://chatgpt.com/codex/tasks/task_e_68831b0cb590832885f7980ecfaa31b9