### PR TITLE
Move Exit option to the end of menus

### DIFF
--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -417,9 +417,9 @@ while true; do
         2 "Install xiRAID Classic" \
         3 "Performance Tuning" \
         4 "Collect HW Keys" \
-        5 "Exit" \
-        6 "RAID Preset" \
-        7 "System Cleanup" \
+        5 "RAID Preset" \
+        6 "System Cleanup" \
+        7 "Exit" \
         3>&1 1>&2 2>&3)
     case "$choice" in
         1) enter_systems ;;
@@ -431,8 +431,8 @@ while true; do
             ;;
         3) run_perf_tuning ;;
         4) ./collect_hw_keys.sh ;;
-        5) exit 2 ;;
-        6) raid_preset ;;
-        7) cleanup_system ;;
+        5) raid_preset ;;
+        6) cleanup_system ;;
+        7) exit 2 ;;
     esac
 done

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -135,12 +135,12 @@ configure_nfs_shares() {
             4 "Edit NFS Exports" \
             5 "Git Repository Configuration" \
             6 "Install xiRAID Classic" \
-            7 "Exit" \
-            8 "Presets" \
+            7 "Presets" \
+            8 "Exit" \
             3>&1 1>&2 2>&3)
         case "$choice" in
             4) ./configure_nfs_exports.sh --edit "$default_path" ;;
-            7) break ;;
+            8) break ;;
         esac
     done
 }
@@ -514,9 +514,9 @@ while true; do
         6 "Install xiRAID Classic" \
         7 "Performance Tuning" \
         8 "Collect HW Keys" \
-        9 "Exit" \
-        10 "RAID Preset" \
-        11 "System Cleanup" \
+        9 "RAID Preset" \
+        10 "System Cleanup" \
+        11 "Exit" \
         3>&1 1>&2 2>&3)
     case "$choice" in
         1) configure_network ;;
@@ -532,9 +532,9 @@ while true; do
             ;;
         7) run_perf_tuning ;;
         8) ./collect_hw_keys.sh ;;
-        9) exit 2 ;;
-        10) raid_preset ;;
-        11) cleanup_system ;;
+        9) raid_preset ;;
+        10) cleanup_system ;;
+        11) exit 2 ;;
     esac
 done
 


### PR DESCRIPTION
## Summary
- reorder main menu in `simple_menu.sh` so Exit is last
- reorder submenus in `startup_menu.sh` so Exit appears last

## Testing
- `shellcheck simple_menu.sh startup_menu.sh post_install_menu.sh`
- `bash -n simple_menu.sh startup_menu.sh post_install_menu.sh`


------
https://chatgpt.com/codex/tasks/task_e_688334b515d483288594a6f9f773bd4e