### PR TITLE
Improve systems list display in simple menu

### DIFF
--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -226,13 +226,12 @@ enter_systems() {
     fi
 
     while true; do
-        local list
-        list=$(printf '%s\n' "${hosts[@]}")
         set +e
         local action status
-        action=$(whiptail --title "Systems" --menu "Current systems:\n$list" 20 70 10 \
+        action=$(whiptail --title "Systems" --menu "Manage systems list:" 20 70 10 \
             Add "Add new system" \
             Remove "Remove a system" \
+            Show "Show current list" \
             Done "Finish" 3>&1 1>&2 2>&3)
         status=$?
         set -e
@@ -282,6 +281,15 @@ enter_systems() {
                             fi
                         done
                     fi
+                fi
+                ;;
+            Show)
+                if [ ${#hosts[@]} -eq 0 ]; then
+                    whiptail --msgbox "Systems list is empty" 8 40
+                else
+                    local tmp="$TMP_DIR/sys_list"
+                    printf '%s\n' "${hosts[@]}" > "$tmp"
+                    whiptail --title "Systems list" --textbox "$tmp" 20 70
                 fi
                 ;;
             Done)


### PR DESCRIPTION
## Summary
- let `enter_systems` offer a separate option to show the current systems list
- remove the truncated list from the main manage menu

## Testing
- `shellcheck simple_menu.sh`

------
https://chatgpt.com/codex/tasks/task_e_688342a0fb148328b5233041840196ba