### PR TITLE
Fix xfsprogs install

### DIFF
--- a/collection/roles/raid_fs/tasks/main.yml
+++ b/collection/roles/raid_fs/tasks/main.yml
@@ -87,7 +87,7 @@
 
 # ----------------------- Filesystem section -------------------
 - name: Ensure XFS utils present
-  ansible.builtin.apt:
+  ansible.builtin.package:
     name: xfsprogs
     state: present
   tags: [raid_fs, fs]


### PR DESCRIPTION
## Summary
- use generic package module for installing XFS utilities

## Testing
- `git diff --color -U3 collection/roles/raid_fs/tasks/main.yml`


------
https://chatgpt.com/codex/tasks/task_e_688763757cdc83288545ccf558efc70b