### PR TITLE
feat: add RHEL support to common role

### DIFF
--- a/collection/roles/common/README.md
+++ b/collection/roles/common/README.md
@@ -1,12 +1,12 @@
 # Role: common
 
-Baseline configuration for all storage nodes. Installs essential packages, configures timezone, NTP, basic kernel tuning and security updates.
+Baseline configuration for all storage nodes. Installs essential packages, configures timezone, NTP, basic kernel tuning and security updates. The role supports both Debian/Ubuntu (apt) and RHEL-based systems (dnf).
 
 ## Variables
 * **`common_timezone`** – system timezone (default `Europe/Amsterdam`).
-* **`common_packages`** – list of baseline packages to install.
+* **`common_packages`** – list of baseline packages to install. Includes either `unattended-upgrades` or `dnf-automatic` depending on the OS family.
 * **`common_sysctl`** – dictionary of sysctl parameters.
-* **`chrony_service_name`** – name of the chrony service to manage (default `chrony`).
+* **`chrony_service_name`** – name of the chrony service to manage (defaults to `chrony` on Debian and `chronyd` on RHEL).
 * **`chrony_package_name`** – name of the chrony package to install (default `chrony`).
 * **`xinas_hostname`** – hostname to set. Defaults to `xiNAS-HWKEY`.
 

--- a/collection/roles/common/defaults/main.yml
+++ b/collection/roles/common/defaults/main.yml
@@ -12,9 +12,9 @@ common_packages:
   - vim
   - htop
   - chrony                # NTP daemon; change to ntp if preferred
-  - unattended-upgrades
+  - "{{ 'unattended-upgrades' if ansible_os_family == 'Debian' else 'dnf-automatic' }}"
   - ca-certificates
-chrony_service_name: chrony
+chrony_service_name: "{{ 'chronyd' if ansible_os_family == 'RedHat' else 'chrony' }}"
 chrony_package_name: chrony
 common_sysctl:
   net.core.rmem_max: 268435456

--- a/collection/roles/common/handlers/main.yml
+++ b/collection/roles/common/handlers/main.yml
@@ -9,3 +9,8 @@
   ansible.builtin.service:
     name: unattended-upgrades
     state: restarted
+
+- name: restart dnf-automatic
+  ansible.builtin.service:
+    name: dnf-automatic.timer
+    state: restarted

--- a/collection/roles/common/tasks/main.yml
+++ b/collection/roles/common/tasks/main.yml
@@ -1,23 +1,45 @@
 # -------------------------------------------------------------
 # tasks/main.yml
 # -------------------------------------------------------------
----
-- name: Update apt cache
+- name: Update package cache (Debian)
   ansible.builtin.apt:
     update_cache: yes
     cache_valid_time: 3600
+  when: ansible_os_family == 'Debian'
   tags: [packages]
 
-- name: Install baseline packages
+- name: Update package cache (RedHat)
+  ansible.builtin.dnf:
+    update_cache: yes
+  when: ansible_os_family == 'RedHat'
+  tags: [packages]
+
+- name: Install baseline packages (Debian)
   ansible.builtin.apt:
     name: "{{ common_packages }}"
     state: present
+  when: ansible_os_family == 'Debian'
   tags: [packages]
 
-- name: Install chrony package
+- name: Install baseline packages (RedHat)
+  ansible.builtin.dnf:
+    name: "{{ common_packages }}"
+    state: present
+  when: ansible_os_family == 'RedHat'
+  tags: [packages]
+
+- name: Install chrony package (Debian)
   ansible.builtin.apt:
     name: "{{ chrony_package_name }}"
     state: present
+  when: ansible_os_family == 'Debian'
+  tags: [ntp]
+
+- name: Install chrony package (RedHat)
+  ansible.builtin.dnf:
+    name: "{{ chrony_package_name }}"
+    state: present
+  when: ansible_os_family == 'RedHat'
   tags: [ntp]
 
 - name: Set timezone
@@ -37,6 +59,7 @@
   ansible.builtin.dpkg_selections:
     name: linux-image-generic
     selection: hold
+  when: ansible_os_family == 'Debian'
   tags: [kernel]
 
 - name: Deploy unattended‑upgrades configuration
@@ -47,6 +70,26 @@
     group: root
     mode: '0644'
   notify: restart unattended-upgrades
+  when: ansible_os_family == 'Debian'
+  tags: [security]
+
+- name: Deploy dnf-automatic configuration
+  ansible.builtin.template:
+    src: dnf-automatic.conf.j2
+    dest: /etc/dnf/automatic.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: restart dnf-automatic
+  when: ansible_os_family == 'RedHat'
+  tags: [security]
+
+- name: Enable and start dnf-automatic timer
+  ansible.builtin.service:
+    name: dnf-automatic.timer
+    enabled: yes
+    state: started
+  when: ansible_os_family == 'RedHat'
   tags: [security]
 
 - name: Apply sysctl parameters

--- a/collection/roles/common/templates/dnf-automatic.conf.j2
+++ b/collection/roles/common/templates/dnf-automatic.conf.j2
@@ -1,0 +1,15 @@
+# -------------------------------------------------------------
+# templates/dnf-automatic.conf.j2
+# -------------------------------------------------------------
+[commands]
+upgrade_type = default
+random_sleep = 0
+download_updates = yes
+apply_updates = yes
+
+[emitters]
+emit_via = stdio
+
+[base]
+debuglevel = 1
+


### PR DESCRIPTION
## Summary
- support dnf on RHEL-like systems in common role
- add dnf-automatic configuration and handler
- document cross-distro behavior

## Testing
- `ansible-playbook -i inventories/example.yml playbooks/common.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_688e5c7b20c88328ad286a341674444a