### PR TITLE
feat: add RHEL support to doca_ofed role

### DIFF
--- a/client_repo/collection/roles/doca_ofed/README.md
+++ b/client_repo/collection/roles/doca_ofed/README.md
@@ -1,9 +1,9 @@
 # Role **doca_ofed**
-Installs NVIDIA DOCA-OFED from the official DOCA APT repository on Ubuntu.
+Installs NVIDIA DOCA-OFED from the official DOCA repository on Debian/Ubuntu and RHEL systems.
 
 Variables:
   * `doca_version` – release version string (`DGX_latest_DOCA` for latest).
-  * `doca_distro_series` – Ubuntu series used in repository path.
+  * `doca_distro_series` – distribution series used in repository path (e.g. `ubuntu24.04`, `rhel9.3`).
   * `doca_repo_base` – base URL of the DOCA repository.
   * `doca_repo_component` – component path built from version and distro.
   * `doca_pkgs` – list of packages to install (kernel stack and userspace).

--- a/client_repo/collection/roles/doca_ofed/defaults/main.yml
+++ b/client_repo/collection/roles/doca_ofed/defaults/main.yml
@@ -1,4 +1,4 @@
-doca_distro_series: "ubuntu24.04"
+doca_distro_series: "{{ ansible_distribution | lower }}{{ ansible_distribution_version }}"
 doca_version: "2.9.1"          # or "DGX_latest_DOCA" for always-latest
 doca_repo_base: "https://linux.mellanox.com/public/repo/doca"
 doca_repo_component: "{{ doca_version }}/{{ doca_distro_series }}/x86_64"

--- a/client_repo/collection/roles/doca_ofed/tasks/main.yml
+++ b/client_repo/collection/roles/doca_ofed/tasks/main.yml
@@ -1,41 +1,92 @@
-- name: Ensure build dependencies are present
-  ansible.builtin.apt:
-    name:
-      - dkms
-      - build-essential
-      - linux-headers-{{ ansible_kernel }}
-      - libelf-dev
-    state: present
-  tags: [ofed, deps]
+## Debian/Ubuntu installation
+- name: Install DOCA-OFED on Debian-based systems
+  when: ansible_os_family == 'Debian'
+  block:
+    - name: Ensure build dependencies are present
+      ansible.builtin.apt:
+        name:
+          - dkms
+          - build-essential
+          - linux-headers-{{ ansible_kernel }}
+          - libelf-dev
+        state: present
+      tags: [ofed, deps]
 
-- name: Add Mellanox GPG key
-  ansible.builtin.apt_key:
-    url: "{{ doca_repo_base }}/GPG-KEY-Mellanox.pub"
-    state: present
-  tags: [ofed, repo]
+    - name: Add Mellanox GPG key
+      ansible.builtin.apt_key:
+        url: "{{ doca_repo_base }}/GPG-KEY-Mellanox.pub"
+        state: present
+      tags: [ofed, repo]
 
-- name: Add DOCA-OFED APT repo
-  ansible.builtin.apt_repository:
-    repo: "deb {{ doca_repo_base }}/{{ doca_repo_component }} /"
-    filename: "mellanox-doca"
-    state: present
-  register: repo_added
-  tags: [ofed, repo]
+    - name: Add DOCA-OFED APT repo
+      ansible.builtin.apt_repository:
+        repo: "deb {{ doca_repo_base }}/{{ doca_repo_component }} /"
+        filename: "mellanox-doca"
+        state: present
+      register: repo_added
+      tags: [ofed, repo]
 
-- name: Update APT cache (if repo added)
-  ansible.builtin.apt:
-    update_cache: yes
-  when: repo_added is changed
-  tags: [ofed, repo]
+    - name: Update APT cache (if repo added)
+      ansible.builtin.apt:
+        update_cache: yes
+      when: repo_added is changed
+      tags: [ofed, repo]
 
-- name: Install DOCA-OFED packages
-  ansible.builtin.apt:
-    name: "{{ doca_pkgs }}"
-    state: present
-    update_cache: yes
-  register: ofed_pkgs
-  notify: restart openibd
-  tags: [ofed, install]
+    - name: Install DOCA-OFED packages
+      ansible.builtin.apt:
+        name: "{{ doca_pkgs }}"
+        state: present
+        update_cache: yes
+      register: ofed_pkgs
+      notify: restart openibd
+      tags: [ofed, install]
+
+## RHEL installation
+- name: Install DOCA-OFED on RHEL-based systems
+  when: ansible_os_family == 'RedHat'
+  block:
+    - name: Ensure build dependencies are present
+      ansible.builtin.yum:
+        name:
+          - dkms
+          - kernel-devel-{{ ansible_kernel }}
+          - gcc
+          - make
+          - elfutils-libelf-devel
+        state: present
+      tags: [ofed, deps]
+
+    - name: Add Mellanox GPG key
+      ansible.builtin.rpm_key:
+        key: "{{ doca_repo_base }}/GPG-KEY-Mellanox.pub"
+        state: present
+      tags: [ofed, repo]
+
+    - name: Add DOCA-OFED YUM repo
+      ansible.builtin.yum_repository:
+        name: mellanox-doca
+        description: Mellanox DOCA Repository
+        baseurl: "{{ doca_repo_base }}/{{ doca_repo_component }}"
+        gpgkey: "{{ doca_repo_base }}/GPG-KEY-Mellanox.pub"
+        gpgcheck: yes
+        enabled: yes
+      register: repo_added
+      tags: [ofed, repo]
+
+    - name: Update YUM cache (if repo added)
+      ansible.builtin.yum:
+        update_cache: yes
+      when: repo_added is changed
+      tags: [ofed, repo]
+
+    - name: Install DOCA-OFED packages
+      ansible.builtin.yum:
+        name: "{{ doca_pkgs }}"
+        state: present
+        update_cache: yes
+      register: ofed_pkgs
+      notify: restart openibd
+      tags: [ofed, install]
 
 - name: Reboot if kernel modules built and reboot requested
   ansible.builtin.reboot:
@@ -43,3 +94,4 @@
     reboot_timeout: 1200
   when: ofed_pkgs is changed and doca_ofed_auto_reboot | bool
   tags: [ofed, reboot]
+

--- a/collection/roles/doca_ofed/README.md
+++ b/collection/roles/doca_ofed/README.md
@@ -1,9 +1,9 @@
 # Role **doca_ofed**
-Installs NVIDIA DOCA-OFED from the official DOCA APT repository on Ubuntu.
+Installs NVIDIA DOCA-OFED from the official DOCA repository on Debian/Ubuntu and RHEL systems.
 
 Variables:
   * `doca_version` – release version string (`DGX_latest_DOCA` for latest).
-  * `doca_distro_series` – Ubuntu series used in repository path.
+  * `doca_distro_series` – distribution series used in repository path (e.g. `ubuntu24.04`, `rhel9.3`).
   * `doca_repo_base` – base URL of the DOCA repository.
   * `doca_repo_component` – component path built from version and distro.
   * `doca_pkgs` – list of packages to install (kernel stack and userspace).

--- a/collection/roles/doca_ofed/defaults/main.yml
+++ b/collection/roles/doca_ofed/defaults/main.yml
@@ -1,4 +1,4 @@
-doca_distro_series: "ubuntu24.04"
+doca_distro_series: "{{ ansible_distribution | lower }}{{ ansible_distribution_version }}"
 doca_version: "2.9.1"          # or "DGX_latest_DOCA" for always-latest
 doca_repo_base: "https://linux.mellanox.com/public/repo/doca"
 doca_repo_component: "{{ doca_version }}/{{ doca_distro_series }}/x86_64"

--- a/collection/roles/doca_ofed/tasks/main.yml
+++ b/collection/roles/doca_ofed/tasks/main.yml
@@ -1,42 +1,94 @@
-- name: Ensure build dependencies are present
-  ansible.builtin.apt:
-    name:
-      - dkms
-      - build-essential
-      - linux-headers-{{ ansible_kernel }}
-      - libelf-dev
-    state: present
-  tags: [ofed, deps]
+## Debian/Ubuntu installation
+- name: Install DOCA-OFED on Debian-based systems
+  when: ansible_os_family == 'Debian'
+  block:
+    - name: Ensure build dependencies are present
+      ansible.builtin.apt:
+        name:
+          - dkms
+          - build-essential
+          - linux-headers-{{ ansible_kernel }}
+          - libelf-dev
+        state: present
+      tags: [ofed, deps]
 
-- name: Add Mellanox GPG key
-  ansible.builtin.apt_key:
-    url: "{{ doca_repo_base }}/GPG-KEY-Mellanox.pub"
-    state: present
-  tags: [ofed, repo]
+    - name: Add Mellanox GPG key
+      ansible.builtin.apt_key:
+        url: "{{ doca_repo_base }}/GPG-KEY-Mellanox.pub"
+        state: present
+      tags: [ofed, repo]
 
-- name: Add DOCA-OFED APT repo
-  ansible.builtin.apt_repository:
-    repo: "deb {{ doca_repo_base }}/{{ doca_repo_component }} /"
-    filename: "mellanox-doca"
-    state: present
-  register: repo_added
-  tags: [ofed, repo]
+    - name: Add DOCA-OFED APT repo
+      ansible.builtin.apt_repository:
+        repo: "deb {{ doca_repo_base }}/{{ doca_repo_component }} /"
+        filename: "mellanox-doca"
+        state: present
+      register: repo_added
+      tags: [ofed, repo]
 
-- name: Update APT cache (if repo added)
-  ansible.builtin.apt:
-    update_cache: yes
-  when: repo_added is changed
-  tags: [ofed, repo]
+    - name: Update APT cache (if repo added)
+      ansible.builtin.apt:
+        update_cache: yes
+      when: repo_added is changed
+      tags: [ofed, repo]
 
-- name: Install DOCA-OFED packages
-  ansible.builtin.apt:
-    name: "{{ doca_pkgs }}"
-    state: present
-    update_cache: yes
-  register: ofed_pkgs
-  notify: restart openibd
-  tags: [ofed, install]
+    - name: Install DOCA-OFED packages
+      ansible.builtin.apt:
+        name: "{{ doca_pkgs }}"
+        state: present
+        update_cache: yes
+      register: ofed_pkgs
+      notify: restart openibd
+      tags: [ofed, install]
 
+## RHEL installation
+- name: Install DOCA-OFED on RHEL-based systems
+  when: ansible_os_family == 'RedHat'
+  block:
+    - name: Ensure build dependencies are present
+      ansible.builtin.yum:
+        name:
+          - dkms
+          - kernel-devel-{{ ansible_kernel }}
+          - gcc
+          - make
+          - elfutils-libelf-devel
+        state: present
+      tags: [ofed, deps]
+
+    - name: Add Mellanox GPG key
+      ansible.builtin.rpm_key:
+        key: "{{ doca_repo_base }}/GPG-KEY-Mellanox.pub"
+        state: present
+      tags: [ofed, repo]
+
+    - name: Add DOCA-OFED YUM repo
+      ansible.builtin.yum_repository:
+        name: mellanox-doca
+        description: Mellanox DOCA Repository
+        baseurl: "{{ doca_repo_base }}/{{ doca_repo_component }}"
+        gpgkey: "{{ doca_repo_base }}/GPG-KEY-Mellanox.pub"
+        gpgcheck: yes
+        enabled: yes
+      register: repo_added
+      tags: [ofed, repo]
+
+    - name: Update YUM cache (if repo added)
+      ansible.builtin.yum:
+        update_cache: yes
+      when: repo_added is changed
+      tags: [ofed, repo]
+
+    - name: Install DOCA-OFED packages
+      ansible.builtin.yum:
+        name: "{{ doca_pkgs }}"
+        state: present
+        update_cache: yes
+      register: ofed_pkgs
+      notify: restart openibd
+      tags: [ofed, install]
+
+# UDEV script deployment (common)
 - name: Deploy InfiniBand UDEV rename script
   ansible.builtin.copy:
     src: configure_ib_udev.sh
@@ -59,3 +111,4 @@
     reboot_timeout: 1200
   when: ofed_pkgs is changed and doca_ofed_auto_reboot | bool
   tags: [ofed, reboot]
+


### PR DESCRIPTION
## Summary
- extend doca_ofed role to install on RHEL via yum
- derive DOCA repository path dynamically from distribution
- document Debian and RHEL support for doca_ofed role

## Testing
- `ansible-playbook playbooks/doca_ofed_install.yml --syntax-check`
- `ansible-playbook client_repo/playbooks/doca_ofed_install.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_688e5cb3e4f88328b864bfffee8ce98b