### PR TITLE
docs: streamline cleanup guidance and update role references

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,8 @@ xiTools is a set of utilities for operating system optimization and automated de
    This now uses `playbooks/xiraid_only.yml` to install xiRAID Classic without applying
    additional roles. An **Exit** option is available if you want to leave without running the playbook.
    On RHEL systems follow the [installation guide](https://xinnor.io/docs/xiRAID-4.3.0/E/en/IG/installing_xiraid_classic_on_rhel.html).
-   Before running the playbook make sure any previous xiRAID packages are removed.
-   On RHEL, RHEL-based or Oracle Linux systems run:
-   ```bash
-   sudo dnf remove xiraid-core && sudo dnf autoremove
-   sudo dnf remove xiraid-repo
-   ```
-   On Ubuntu or Proxmox use:
-   ```bash
-   sudo apt remove xiraid-appimage xiraid-core xiraid-kmod
-   sudo apt remove xiraid-repo
-   sudo apt autoremove
-   ```
+   Before running the playbook make sure any previous xiRAID packages are removed using
+   [`playbooks/system_cleanup.yml`](playbooks/system_cleanup.yml) or the **System Cleanup** menu option.
 
 4. Choose **System Cleanup** to remove xiRAID and tuning packages from all hosts. This runs `playbooks/system_cleanup.yml` and keeps your inventory intact.
 
@@ -42,7 +32,7 @@ xiTools is a set of utilities for operating system optimization and automated de
    from there. If you choose to install DOCA OFED using the provided playbook,
    the script will automatically install Ansible packages when needed.
 
-The `start.sh` script installs dependencies required by the interactive helper scripts. It works on both Ubuntu and RedHat-like systems by selecting `apt`, `dnf`, or `yum` as needed. The helper scripts rely on the [`mikefarah/yq`](https://github.com/mikefarah/yq) binary (v4+). If you encounter errors such as `jq: error: env/1 is not defined`, make sure this version of `yq` is installed by re-running `start.sh` or installing it manually.
+The `start.sh` script installs dependencies required by the interactive helper scripts. It works on both Ubuntu and RedHat-like systems by selecting `apt`, `dnf`, or `yum` as needed. The helper scripts rely on the [`mikefarah/yq`](https://github.com/mikefarah/yq) binary (v4+). If you encounter an error like `Error: env/1 is not defined` from `yq`, make sure this version of `yq` is installed by re-running `start.sh` or installing it manually.
 The playbooks also use Ansible's `json_query` filter, which depends on the
 `jmespath` Python library. Recent updates to `start.sh` and
 `client_repo/client_setup.sh` automatically install the `python3-jmespath`

--- a/collection/roles/nfs_server/README.md
+++ b/collection/roles/nfs_server/README.md
@@ -1,6 +1,6 @@
 # Role **nfs_server**
 Installs and tunes `nfs-kernel-server` for RDMA access, with defaults based on
-Xinnor's high-performance NFS blog (Feb 3 2025).
+Xinnor's high-performance NFS blog.
 
 ## Variables
 * `nfs_threads` – thread count for exportd & nfsd (default 64).
@@ -13,4 +13,4 @@ Xinnor's high-performance NFS blog (Feb 3 2025).
     - nfs_server
 ```
 
-Reference: Xinnor blog, Feb 3 2025
+Reference: Xinnor blog

--- a/collection/roles/raid_fs/README.md
+++ b/collection/roles/raid_fs/README.md
@@ -28,4 +28,4 @@ without failing.
     - raid_fs
 ```
 
-Blog reference: “How to Build High-Performance NFS Storage with xiRAID Backend and RDMA Access”, Feb 3 2025
+Blog reference: “How to Build High-Performance NFS Storage with xiRAID Backend and RDMA Access”.


### PR DESCRIPTION
## Summary
- point users to system_cleanup playbook instead of manual package removal
- clarify yq error message
- drop outdated Feb 3 2025 dates from role docs

## Testing
- `ansible-playbook --syntax-check playbooks/system_cleanup.yml`


------
https://chatgpt.com/codex/tasks/task_e_688e5dd017308328bb45e03cd8947448