### PR TITLE
Add license activation option to collect_hw_keys script

### DIFF
--- a/collect_hw_keys.sh
+++ b/collect_hw_keys.sh
@@ -46,6 +46,19 @@ main() {
     done
 
     show_hwkeys "$inventory"
+
+    if read -r -p "Activate license on all nodes? [y/N] " reply && [[ $reply =~ ^[Yy]$ ]]; then
+        local lic_path
+        while true; do
+            read -r -p "Enter path to license file: " lic_path
+            if [ -f "$lic_path" ]; then
+                ansible storage_nodes -i "$inventory" -b -m shell -a "xicli licence update -p '$lic_path'" -o
+                break
+            else
+                echo "File not found: $lic_path"
+            fi
+        done
+    fi
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- prompt to activate licenses across nodes after displaying hardware keys
- validate license file path and run `xicli licence update` on each node

## Testing
- `bash -n collect_hw_keys.sh`
- `./collect_hw_keys.sh -h`


------
https://chatgpt.com/codex/tasks/task_e_6891e96b3e808328a842ff5983fb286a