### PR TITLE
Unify menus with curses TUI

### DIFF
--- a/post_install_menu.sh
+++ b/post_install_menu.sh
@@ -135,34 +135,34 @@ store_config_repo() {
 }
 
 while true; do
-    menu_items=(
-        1 "RAID Groups information"
-        2 "xiRAID license information"
-        3 "File system and NFS share information"
-        4 "Network post install settings"
+    options=(
+        "RAID Groups information"
+        "xiRAID license information"
+        "File system and NFS share information"
+        "Network post install settings"
     )
-    save_opt=5
     if is_custom_repo && has_repo_changes; then
-        menu_items+=("$save_opt" "Store configuration to Git repository")
-        exit_opt=$((save_opt + 1))
-    else
-        exit_opt=$save_opt
+        options+=("Store configuration to Git repository")
     fi
-    menu_items+=("$exit_opt" "Exit")
+    options+=("Exit")
 
-    choice=$(whiptail --title "Post Install Menu" --menu "Select an option:" 20 70 10 "${menu_items[@]}" 3>&1 1>&2 2>&3)
+    set +e
+    choice=$(./tui_menu.py --title "Post Install Menu" "${options[@]}")
+    status=$?
+    set -e
+    [ $status -ne 0 ] && break
     case "$choice" in
-        1) show_raid_info ;;
-        2) show_license_info ;;
-        3) show_nfs_info ;;
-        4) manage_network ;;
-        "$save_opt")
+        "RAID Groups information") show_raid_info ;;
+        "xiRAID license information") show_license_info ;;
+        "File system and NFS share information") show_nfs_info ;;
+        "Network post install settings") manage_network ;;
+        "Store configuration to Git repository")
             if is_custom_repo && has_repo_changes; then
                 store_config_repo
             else
                 break
             fi
             ;;
-        *) break ;;
+        "Exit") break ;;
     esac
 done

--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -420,27 +420,30 @@ cleanup_system() {
 }
 
 while true; do
-    choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 15 70 9 \
-        1 "Systems list" \
-        2 "Install xiRAID Classic" \
-        3 "Performance Tuning" \
-        4 "Collect HW Keys" \
-        5 "RAID Preset" \
-        6 "System Cleanup" \
-        7 "Exit" \
-        3>&1 1>&2 2>&3)
+    set +e
+    choice=$(./tui_menu.py --title "xiNAS Setup" \
+        "Systems list" \
+        "Install xiRAID Classic" \
+        "Performance Tuning" \
+        "Collect HW Keys" \
+        "RAID Preset" \
+        "System Cleanup" \
+        "Exit")
+    status=$?
+    set -e
+    [ $status -ne 0 ] && exit 2
     case "$choice" in
-        1) enter_systems ;;
-        2)
+        "Systems list") enter_systems ;;
+        "Install xiRAID Classic")
             if check_remove_xiraid && confirm_playbook "playbooks/xiraid_only.yml"; then
                 run_playbook "playbooks/xiraid_only.yml" "inventories/lab.ini"
                 whiptail --msgbox "Installation completed. Returning to main menu." 8 60 || true
             fi
             ;;
-        3) run_perf_tuning ;;
-        4) ./collect_hw_keys.sh ;;
-        5) raid_preset ;;
-        6) cleanup_system ;;
-        7) exit 2 ;;
+        "Performance Tuning") run_perf_tuning ;;
+        "Collect HW Keys") ./collect_hw_keys.sh ;;
+        "RAID Preset") raid_preset ;;
+        "System Cleanup") cleanup_system ;;
+        "Exit") exit 2 ;;
     esac
 done

--- a/startup_menu.sh
+++ b/startup_menu.sh
@@ -505,36 +505,39 @@ cleanup_system() {
 }
 # Main menu loop
 while true; do
-    choice=$(whiptail --title "xiNAS Setup" --nocancel --menu "Choose an action:" 20 70 17 \
-        1 "Configure Network" \
-        2 "Set Hostname" \
-        3 "Configure RAID" \
-        4 "Edit NFS Exports" \
-        5 "Git Repository Configuration" \
-        6 "Install xiRAID Classic" \
-        7 "Performance Tuning" \
-        8 "Collect HW Keys" \
-        9 "RAID Preset" \
-        10 "System Cleanup" \
-        11 "Exit" \
-        3>&1 1>&2 2>&3)
+    set +e
+    choice=$(./tui_menu.py --title "xiNAS Setup" \
+        "Configure Network" \
+        "Set Hostname" \
+        "Configure RAID" \
+        "Edit NFS Exports" \
+        "Git Repository Configuration" \
+        "Install xiRAID Classic" \
+        "Performance Tuning" \
+        "Collect HW Keys" \
+        "RAID Preset" \
+        "System Cleanup" \
+        "Exit")
+    status=$?
+    set -e
+    [ $status -ne 0 ] && exit 2
     case "$choice" in
-        1) configure_network ;;
-        2) configure_hostname ;;
-        3) configure_raid ;;
-        4) edit_nfs_exports ;;
-        5) configure_git_repo ;;
-        6)
+        "Configure Network") configure_network ;;
+        "Set Hostname") configure_hostname ;;
+        "Configure RAID") configure_raid ;;
+        "Edit NFS Exports") edit_nfs_exports ;;
+        "Git Repository Configuration") configure_git_repo ;;
+        "Install xiRAID Classic")
             if check_remove_xiraid && confirm_playbook "playbooks/xiraid_only.yml"; then
                 run_playbook "playbooks/xiraid_only.yml"
                 whiptail --msgbox "Installation completed. Returning to main menu." 8 60 || true
             fi
             ;;
-        7) run_perf_tuning ;;
-        8) ./collect_hw_keys.sh ;;
-        9) raid_preset ;;
-        10) cleanup_system ;;
-        11) exit 2 ;;
+        "Performance Tuning") run_perf_tuning ;;
+        "Collect HW Keys") ./collect_hw_keys.sh ;;
+        "RAID Preset") raid_preset ;;
+        "System Cleanup") cleanup_system ;;
+        "Exit") exit 2 ;;
     esac
 done
 

--- a/tui_menu.py
+++ b/tui_menu.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Simple curses-based menu used across xiTools."""
+import argparse
+import curses
+import sys
+
+
+def run_menu(options, title="Menu"):
+    selected = 0
+
+    def draw(stdscr):
+        nonlocal selected
+        curses.curs_set(0)
+        stdscr.keypad(True)
+        while True:
+            max_y, max_x = stdscr.getmaxyx()
+            stdscr.erase()
+            stdscr.addnstr(0, 0, title.ljust(max_x), max_x, curses.A_REVERSE)
+            for idx, opt in enumerate(options):
+                attr = curses.A_REVERSE if idx == selected else curses.A_NORMAL
+                stdscr.addnstr(idx + 1, 0, opt.ljust(max_x), max_x, attr)
+            ch = stdscr.getch()
+            if ch in (curses.KEY_UP, ord('k')) and selected > 0:
+                selected -= 1
+            elif ch in (curses.KEY_DOWN, ord('j')) and selected < len(options) - 1:
+                selected += 1
+            elif ch in (curses.KEY_ENTER, 10, 13):
+                break
+            elif ch in (27, ord('q')):
+                selected = -1
+                break
+
+    curses.wrapper(draw)
+    if selected >= 0:
+        print(options[selected])
+        return 0
+    return 1
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Display a simple curses menu")
+    parser.add_argument("options", nargs="+", help="Menu options")
+    parser.add_argument("--title", default="Menu", help="Menu title")
+    args = parser.parse_args()
+    sys.exit(run_menu(args.options, args.title))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add reusable curses-based `tui_menu.py`
- switch `simple_menu.sh`, `post_install_menu.sh`, and `startup_menu.sh` to the unified menu

## Testing
- `python -m py_compile tui_menu.py`
- `bash -n simple_menu.sh`
- `bash -n post_install_menu.sh`
- `bash -n startup_menu.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895f4360dec8328a28a917db21d118a