### PR TITLE
Preserve TTY when launching curses menu

### DIFF
--- a/simple_menu.sh
+++ b/simple_menu.sh
@@ -421,15 +421,17 @@ cleanup_system() {
 
 while true; do
     set +e
-    choice=$(./tui_menu.py --title "xiNAS Setup" \
+    ./tui_menu.py --title "xiNAS Setup" \
+        --output "$TMP_DIR/menu_choice" \
         "Systems list" \
         "Install xiRAID Classic" \
         "Performance Tuning" \
         "Collect HW Keys" \
         "RAID Preset" \
         "System Cleanup" \
-        "Exit")
+        "Exit"
     status=$?
+    choice=$(cat "$TMP_DIR/menu_choice" 2>/dev/null || true)
     set -e
     [ $status -ne 0 ] && exit 2
     case "$choice" in

--- a/tui_menu.py
+++ b/tui_menu.py
@@ -5,7 +5,21 @@ import curses
 import sys
 
 
-def run_menu(options, title="Menu"):
+def run_menu(options, title="Menu", output=None):
+    """Run a simple curses menu.
+
+    Parameters
+    ----------
+    options: list[str]
+        List of options to present to the user.
+    title: str
+        Title displayed at the top of the menu.
+    output: file-like object or None
+        When provided, the selected option will be written to this file
+        instead of standard output. This allows callers to keep stdout
+        attached to the terminal for curses while capturing the result
+        via a different file descriptor.
+    """
     selected = 0
 
     def draw(stdscr):
@@ -39,7 +53,8 @@ def run_menu(options, title="Menu"):
     except KeyboardInterrupt:
         selected = -1
     if selected >= 0:
-        print(options[selected])
+        target = output if output is not None else sys.stdout
+        print(options[selected], file=target)
         return 0
     return 1
 
@@ -48,8 +63,16 @@ def main():
     parser = argparse.ArgumentParser(description="Display a simple curses menu")
     parser.add_argument("options", nargs="+", help="Menu options")
     parser.add_argument("--title", default="Menu", help="Menu title")
+    parser.add_argument("--output", help="File to write the selected option to")
     args = parser.parse_args()
-    sys.exit(run_menu(args.options, args.title))
+
+    out_file = open(args.output, "w") if args.output else None
+    try:
+        rc = run_menu(args.options, args.title, out_file)
+    finally:
+        if out_file is not None:
+            out_file.close()
+    sys.exit(rc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow `tui_menu.py` to write selected menu item to a file instead of stdout
- call `tui_menu.py` with `--output` in `simple_menu.sh` so curses keeps terminal access

## Testing
- `python3 tui_menu.py --help`
- `bash -n simple_menu.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895fe97b93083288701a1bb96e79b86