### PR TITLE
fix: correct repository link in start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -39,8 +39,8 @@ if [ "$UPDATE_ONLY" -eq 0 ]; then
     sudo chmod +x /usr/local/bin/yq
 fi
 
-REPO_URL="https://github.com/XinnorLab/xiNAS/"
-REPO_DIR="xiNAS"
+REPO_URL="https://github.com/XinnorLab/xiTools/"
+REPO_DIR="xiTools"
 
 # Determine if repo already exists in current directory
 if [ -f "ansible.cfg" ] && [ -d "playbooks" ]; then


### PR DESCRIPTION
## Summary
- point start script to the xiTools repository instead of xiNAS

## Testing
- `bash start.sh -h`
- `bash -n start.sh`


------
https://chatgpt.com/codex/tasks/task_e_6897b38ed38c8328a7339d0bc0e59baf