### PR TITLE
Fix parse_size precision and add tests

### DIFF
--- a/block-info
+++ b/block-info
@@ -7,6 +7,7 @@ import sys
 import fnmatch
 import re
 import curses
+from decimal import Decimal, InvalidOperation
 from typing import List, Dict, Any
 
 
@@ -30,7 +31,10 @@ def parse_size(size_str: str) -> int:
     match = re.fullmatch(r"(?i)\s*(\d+(?:\.\d+)?)([kmgtpe]?i?b?)?\s*", size_str)
     if not match:
         raise ValueError(f"Invalid size: {size_str}")
-    number = float(match.group(1))
+    try:
+        number = Decimal(match.group(1))
+    except InvalidOperation:
+        raise ValueError(f"Invalid size: {size_str}")
     suffix = match.group(2).lower() if match.group(2) else ''
     multipliers = {
         '': 1,

--- a/tests/test_parse_size.py
+++ b/tests/test_parse_size.py
@@ -1,0 +1,15 @@
+import runpy
+from decimal import Decimal
+
+mod = runpy.run_path('block-info')
+parse_size = mod['parse_size']
+
+
+def test_parse_size_large_integer():
+    val = 18446744073709551615
+    assert parse_size(str(val)) == val
+
+
+def test_parse_size_fractional_with_suffix():
+    expected = int(Decimal('1.5') * (1024 ** 4))
+    assert parse_size('1.5T') == expected


### PR DESCRIPTION
## Summary
- avoid float rounding when parsing device sizes by switching to `Decimal`
- add tests covering very large values and fractional units

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2f730b9e483289140819d4c3adbbc