### PR TITLE
Add group reporting to fio parameters

### DIFF
--- a/nvme_fio.py
+++ b/nvme_fio.py
@@ -128,6 +128,7 @@ def run_fio(
         "--time_based",
         f"--runtime={RUNTIME_SECONDS}",
         "--output-format=json",
+        "--group_reporting",
     ]
     try:
         out = subprocess.check_output(cmd, text=True)


### PR DESCRIPTION
## Summary
- aggregate fio metrics across jobs by enabling group reporting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a31c150aa88328a1a2f956e1a652b1